### PR TITLE
Adds batchfile generation (not integrated with binstub generation yet)

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -45,8 +45,30 @@ module Appbundler
       File.join(app_root, "Gemfile.lock")
     end
 
+    def ruby
+      Gem.ruby
+    end
+
+    def batchfile_stub
+      ruby_relpath_windows = ruby_relative_path.gsub('/', '\\')
+      <<-E
+@ECHO OFF
+"%~dp0\\#{ruby_relpath_windows}" "%~dpn0" %*
+E
+    end
+
+    # Relative path from #target_bin_dir to #ruby. This is used to
+    # generate batch files for windows in a way that the package can be
+    # installed in a custom location. On Unix we don't support custom
+    # install locations so this isn't needed.
+    def ruby_relative_path
+      ruby_pathname = Pathname.new(ruby)
+      bindir_pathname = Pathname.new(target_bin_dir)
+      ruby_pathname.relative_path_from(bindir_pathname).to_s
+    end
+
     def shebang
-      "#!#{Gem.ruby}\n"
+      "#!#{ruby}\n"
     end
 
     # A specially formatted comment that documents the format version of the


### PR DESCRIPTION
Putting this up here for early feedback:
- Is the batch file code correct?
- How do we pass paths into the appbundler CLI at the moment? If we want the CLI to accept paths with backslashes, we'll need to translate them on the way in since ruby only deals with '/' separators internally.
