### PR TITLE
Added a switch to exclude bins

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -16,9 +16,10 @@ module Appbundler
       puts demo.binstub(knife)
     end
 
-    def initialize(app_root, target_bin_dir)
+    def initialize(app_root, target_bin_dir, exclusions)
       @app_root = app_root
       @target_bin_dir = target_bin_dir
+      @exclusions = exclusions
     end
 
     def write_executable_stubs
@@ -135,7 +136,9 @@ E
 
     def executables
       bin_dir_glob = File.join(app_root, "bin", "*")
-      Dir[bin_dir_glob]
+      Dir[bin_dir_glob].reject do |bin_path|
+        @exclusions.include? File.basename(bin_path)
+      end
     end
 
     def relative_app_lib_dir

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -100,7 +100,7 @@ BANNER
     end
 
     def run
-      created_stubs = App.new(app_path, bin_path).write_executable_stubs
+      created_stubs = App.new(app_path, bin_path, ::Appbundler::Config.exclusions).write_executable_stubs
       created_stubs.each do |real_executable_path, stub_path|
         $stdout.puts "Generated binstub #{stub_path} => #{real_executable_path}"
       end

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -1,4 +1,5 @@
 require 'appbundler/version'
+require 'appbundler/config'
 require 'appbundler/app'
 require 'mixlib/cli'
 
@@ -35,6 +36,11 @@ BANNER
       :boolean => true,
       :show_options => true,
       :exit => 0
+
+    option :exclude,
+      :long => '--exclude BIN',
+      :description => 'Binary to exclude',
+      :proc => lambda {|bin| Appbundler::Config.exclusions << bin}
 
     def self.run(argv)
       cli = new(argv)

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -13,6 +13,12 @@ Usage: appbundler APPLICATION_DIR BINSTUB_DIR
   BINSTUB_DIR is the directory where you want generated executables to be written
 BANNER
 
+    attr_reader :argv
+
+    attr_reader :app_path
+    attr_reader :bin_path
+
+
     option :version,
       :short => '-v',
       :long => '--version',
@@ -36,11 +42,6 @@ BANNER
       cli.validate!
       cli.run
     end
-
-    attr_reader :argv
-
-    attr_reader :app_path
-    attr_reader :bin_path
 
     def initialize(argv)
       @argv = argv

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -66,6 +66,7 @@ BANNER
         @bin_path = File.expand_path(cli_arguments[1])
         verify_app_path
         verify_bin_path
+        verify_excludes
       end
     end
 
@@ -82,6 +83,18 @@ BANNER
     def verify_bin_path
       if !File.directory?(bin_path)
         err("BINSTUB_DIR `#{bin_path}' is not a directory or doesn't exist")
+        usage_and_exit!
+      end
+    end
+
+    def verify_excludes
+      missing_bins = ::Appbundler::Config.exclusions.reject do |bin|
+        File.exists?(File.join(app_path, 'bin', bin))
+      end
+      if not missing_bins.empty?
+        missing_bins.each do |bin|
+          err("APPLICATION_DIR/bin does not contain #{bin}")
+        end
         usage_and_exit!
       end
     end

--- a/lib/appbundler/config.rb
+++ b/lib/appbundler/config.rb
@@ -1,0 +1,9 @@
+module Appbundler
+  class Config
+
+    # A list of files to exclude
+    def self.exclusions
+      @exclusions ||= []
+    end
+  end
+end

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -57,7 +57,7 @@ describe Appbundler do
     let(:app_root) { "/opt/app/embedded/apps/app" }
 
     let(:app) do
-      Appbundler::App.new(app_root, target_bindir)
+      Appbundler::App.new(app_root, target_bindir, [])
     end
 
     before do
@@ -157,7 +157,7 @@ E
     let(:app_root) { APP_ROOT }
 
     let(:app) do
-      Appbundler::App.new(APP_ROOT, target_bindir)
+      Appbundler::App.new(APP_ROOT, target_bindir, [])
     end
 
     before(:all) do

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -157,7 +157,7 @@ E
     let(:app_root) { APP_ROOT }
 
     let(:app) do
-      Appbundler::App.new(APP_ROOT, target_bindir, [])
+      Appbundler::App.new(APP_ROOT, target_bindir, ['exclude-me'])
     end
 
     before(:all) do
@@ -223,6 +223,10 @@ E
       expect(app.runtime_activate).to include(expected_gem_activates)
     end
 
+    it "should not contain exclude-me as a binary" do
+      expect(app.executables).not_to include(File.join(app_root, "/bin", "exclude-me"))
+    end
+
     it "lists the app's executables" do
       expected_executables = %w[app-binary-1 app-binary-2].map do |basename|
         File.join(app_root, "/bin", basename)
@@ -251,8 +255,10 @@ E
       app.write_executable_stubs
       binary_1 = File.join(target_bindir, "app-binary-1")
       binary_2 = File.join(target_bindir, "app-binary-2")
+      excluded_binary = File.join(target_bindir, "exclude-me")
       expect(File.exist?(binary_1)).to be_true
       expect(File.exist?(binary_2)).to be_true
+      expect(File.exist?(excluded_binary)).to be_false
       expect(File.executable?(binary_1)).to be_true
       expect(File.executable?(binary_1)).to be_true
       expect(shellout!(binary_1).stdout).to eq("binary 1 ran\n")

--- a/spec/fixtures/example-app/bin/exclude-me
+++ b/spec/fixtures/example-app/bin/exclude-me
@@ -1,0 +1,2 @@
+#!/usr/bin/env ruby
+puts "exclude-me should not have run"

--- a/spec/fixtures/example-app/example-app.gemspec
+++ b/spec/fixtures/example-app/example-app.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = ""
   spec.license       = "Apache2"
 
-  spec.files         = Dir.glob("{bin,lib,spec}/**/*").reject {|f| File.directory?(f) }
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files         = Dir.glob("{lib,spec}/**/*").reject {|f| File.directory?(f) }
+  spec.executables   = %w(app-binary-1 app-binary-2)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
Allowing appbundler to exclude bins. Once this is in, we can pass whatever we need to from omnibus.

As an example
```
bundle exec appbundler ~/workspace/chef ~/appbundled-bins --exclude chef-service-manager --exclude chef-solo
```