### PR TITLE
Exclude bundler from the appbundle

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -172,6 +172,7 @@ E
 
     def add_dependencies_from(spec, collected_deps=[])
       spec.dependencies.each do |dep|
+        next if dep.name == "bundler"
         next if collected_deps.any? {|s| s.name == dep.name }
         next_spec = spec_for(dep.name)
         collected_deps << next_spec


### PR DESCRIPTION
@danielsdeleo @lamont-granquist Refs #4, but I just hit this issue while trying to Omnibus Vagrant. If there is a runtime dep on bundler and it exists in the Gemfile.lock, appbundle will fail.

This seems super hacky, so I'm open to other ideas, but :panda_face:.