### PR TITLE
omit locking bundler

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -178,6 +178,8 @@ E
     def add_dependencies_from(spec, collected_deps=[])
       spec.dependencies.each do |dep|
         next if collected_deps.any? {|s| s.name == dep.name }
+        # a bunlder dep will not get pinned in Gemfile.lock
+        next if dep.name == "bundler"
         next_spec = spec_for(dep.name)
         collected_deps << next_spec
         add_dependencies_from(next_spec, collected_deps)

--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -178,7 +178,7 @@ E
     def add_dependencies_from(spec, collected_deps=[])
       spec.dependencies.each do |dep|
         next if collected_deps.any? {|s| s.name == dep.name }
-        # a bunlder dep will not get pinned in Gemfile.lock
+        # a bundler dep will not get pinned in Gemfile.lock
         next if dep.name == "bundler"
         next_spec = spec_for(dep.name)
         collected_deps << next_spec


### PR DESCRIPTION
Bundler doesn't emit equality pins for bundler itself if its a runtime
dep of one of the gems it is bundling.  For now just skip it.  I
suppose we could assume that the bundler we ran to bundle install is
the bundler that will run so we could `bundle --version` and use that
one.  The perf hit from rubygems loading up bundler is probably low
enough not to worry too hard about this right now though...