### PR TITLE
apply some default gc tuning

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -127,8 +127,19 @@ E
       end
     end
 
+    # Apply some default tuning to the ruby GC, there is a memory-speed tradoff here and
+    # we allow users to override these settings.
+    def gc_tuning
+      <<-EOM
+      ENV["RUBY_GC_HEAP_GROWTH_FACTOR"] ||= "1.2"
+      ENV["RUBY_GC_MALLOC_LIMIT_GROWTH_FACTOR"] ||= "1.2"
+      ENV["RUBY_GC_OLDMALLOC_LIMIT_GROWTH_FACTOR"] ||= "1.2"
+      ENV["RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR"] ||= "1.2"
+      EOM
+    end
+
     def binstub(bin_file)
-      shebang + file_format_comment + runtime_activate + load_statement_for(bin_file)
+      shebang + file_format_comment + gc_tuning + runtime_activate + load_statement_for(bin_file)
     end
 
     def load_statement_for(bin_file)


### PR DESCRIPTION
the default ruby tuning is highly wasteful of memory.  this tunes
the expansion of data structures so that they grow only 20% every
time they run out of room.  that runs the GC more often and chews
a bit more CPU but will make memory behavior more well-behaved.