### PR TITLE
Fail when there are inaccessible git-sourced deps

### DIFF
--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -63,6 +63,7 @@ BANNER
         verify_app_path
         verify_bin_path
         verify_gem_installed
+        verify_deps_are_accessible
       end
     end
 
@@ -90,6 +91,11 @@ BANNER
       err("Unable to find #{app.app_spec.name} #{app.app_spec.version} installed as a gem")
       err("You must install the top-level app as a gem before calling app-bundler")
       usage_and_exit!
+    end
+
+    def verify_deps_are_accessible
+      app = App.new(app_path, bin_path)
+      app.verify_deps_are_accessible!
     end
 
     def run

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -7,6 +7,8 @@ module Appbundler
     include Mixlib::CLI
 
     banner(<<-BANNER)
+* appbundler #{VERSION} *
+
 Usage: appbundler APPLICATION_DIR BINSTUB_DIR
 
   APPLICATION_DIR is the root directory to a working copy of your app
@@ -96,6 +98,9 @@ BANNER
     def verify_deps_are_accessible
       app = App.new(app_path, bin_path)
       app.verify_deps_are_accessible!
+    rescue InaccessibleGemsInLockfile => e
+      err(e.message)
+      exit 1
     end
 
     def run

--- a/lib/appbundler/version.rb
+++ b/lib/appbundler/version.rb
@@ -1,3 +1,3 @@
 module Appbundler
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
Adds a sanity check to ensure all git-sourced gems in the app's Gemfile.lock can be found by rubygems (using `Gem::Specification.find_by_name`). This makes appbundler fail in the case that the Gemfile.lock has gems installed from git which are not installed by other means; such executables are not viable, they will fail with errors like described in https://github.com/chef/chef-dk/issues/718