### PR TITLE
clear paths in addition to overriding GEM_HOME and GEM_PATH

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -113,7 +113,12 @@ E
     # APPBUNDLER_ALLOW_RVM environment variable to "true". This feature
     # exists to make tests run correctly on travis.ci (which uses rvm).
     def env_sanitizer
-      %Q{ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"}
+      <<-SANITIZE
+unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+  Gem.clear_paths
+  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil
+end
+SANITIZE
     end
 
     def runtime_activate

--- a/lib/appbundler/version.rb
+++ b/lib/appbundler/version.rb
@@ -1,3 +1,3 @@
 module Appbundler
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -110,8 +110,14 @@ CODE
       expect(app.load_statement_for(bin_path)).to eq(expected_loading_code)
     end
 
-    it "generates code to override GEM_HOME and GEM_PATH (e.g., rvm)" do
-      expected = %Q{ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"}
+    it "generates code to clear paths and override GEM_HOME and GEM_PATH (e.g., rvm)" do
+      expected =       <<-SANITIZE
+unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+  Gem.clear_paths
+  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil
+end
+SANITIZE
+
       expect(app.env_sanitizer).to eq(expected)
       expect(app.runtime_activate).to include(expected)
     end
@@ -234,7 +240,11 @@ E
     it "generates runtime activation code for the app" do
       expected_gem_activates= if windows?
                           <<-E
-ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+  Gem.clear_paths
+  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil
+end
+
 gem "chef", "= 12.4.1"
 gem "chef-config", "= 12.4.1"
 gem "mixlib-config", "= 2.2.1"
@@ -296,7 +306,11 @@ gem "windows-pr", "= 1.2.4"
 E
                           else
           <<-E
-ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+  Gem.clear_paths
+  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil
+end
+
 gem "chef", "= 12.4.1"
 gem "chef-config", "= 12.4.1"
 gem "mixlib-config", "= 2.2.1"


### PR DESCRIPTION
`nil`ing `GEM_HOME` and `GEM_PATH` is only effective if done before `Gem.paths` is initialized. Ruby 2.3.0 initializes `Gem.paths` earlier than previous versions and therefore when activating gems, ruby may be pointed to the wrong paths. Calling `Gem.clear_paths` resets the paths and overriding `GEM_HOME` and `GEM_PATH` afterwards effectively activates gems from the desired location.