### PR TITLE
appbundler 0.10.0 backcompat fixes

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -53,7 +53,7 @@ module Appbundler
     ]
 
     def external_lockfile?
-      app_dir != File.dirname(gemfile_lock)
+      app_dir != bundle_path
     end
 
     def local_gemfile_lock_specs
@@ -244,7 +244,7 @@ E
     end
 
     def executables
-      spec = app_gemspec
+      spec = installed_spec
       spec.executables.map { |e| spec.bin_file(e) }
     end
 
@@ -260,16 +260,24 @@ E
       @app_dependency_names ||= app_spec.dependencies.map(&:name)
     end
 
-    def app_gemspec
+    def installed_spec
       Gem::Specification.find_by_name(app_spec.name, app_spec.version)
     end
 
     def app_spec
-      spec_for(name)
+      if name.nil?
+        Gem::Specification.load("#{bundle_path}/#{File.basename(@bundle_path)}.gemspec")
+      else
+        spec_for(name)
+      end
     end
 
     def app_dir
-      app_gemspec.gem_dir
+      if name.nil?
+        File.dirname(app_spec.loaded_from)
+      else
+        installed_spec.gem_dir
+      end
     end
 
     def gemfile_lock_specs

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -73,11 +73,9 @@ BANNER
         @bundle_path = File.expand_path(cli_arguments[0])
         @bin_path = File.expand_path(cli_arguments[1])
         @gems = cli_arguments[2..-1]
-        @gems = [ File.basename(@bundle_path) ] if @gems.empty?
+        @gems = [ nil ] if @gems.empty?
         verify_bundle_path
         verify_bin_path
-        verify_gems_installed
-        verify_deps_are_accessible
       end
     end
 
@@ -95,31 +93,6 @@ BANNER
       if !File.directory?(bin_path)
         err("BINSTUB_DIR `#{bin_path}' is not a directory or doesn't exist")
         usage_and_exit!
-      end
-    end
-
-    def verify_gems_installed
-      gems.each do |g|
-        begin
-          app = App.new(bundle_path, bin_path, g)
-          app.app_gemspec
-        rescue Gem::LoadError
-          err("Unable to find #{app.app_spec.name} #{app.app_spec.version} installed as a gem")
-          err("You must install the top-level app as a gem before calling app-bundler")
-          usage_and_exit!
-        end
-      end
-    end
-
-    def verify_deps_are_accessible
-      gems.each do |g|
-        begin
-          app = App.new(bundle_path, bin_path, g)
-          app.verify_deps_are_accessible!
-        rescue InaccessibleGemsInLockfile => e
-          err(e.message)
-          exit 1
-        end
       end
     end
 


### PR DESCRIPTION
appbundler /tmp/chef /opt/chef/bin

should work like it used to in 0.10 now and pull the lock pins out of
/tmp/chef and use that to pin the gem which is there.

appbundler /tmp/chef-dk /opt/chef/bin foodcritic

works like 0.11.0 and does the transitive pinning between the
Gemfile.lock in /tmp/chef-dk and the gems in the installed
foodcritic gem, generating the appbundle against the main Gemfile.lock
pins and generating the transitive Gemfile.lock into the foodcritic
directory.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>