### PR TITLE
work around rubygems uninitialized constant error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
+language: ruby
+cache: bundler
+dist: trusty
+
 before_install:
   - gem update --system
   - gem install bundler
 
 rvm:
-  - 2.2.5
-  - 2.3.1
+  - 2.4.4
+  - 2.5.1
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,8 @@ branches:
   only:
     - master
 
+install:
+  - bundle install --jobs 3 --retry 3
+
 # The integration tests need to see installed gems.
 script: rspec --color --format progress

--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -227,6 +227,14 @@ E
       <<-EOS
 ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
 require "rubygems"
+
+begin
+  # this works around rubygems/rubygems#2196 and can be removed in rubygems > 2.7.6
+  require "rubygems/bundler_version_finder"
+rescue LoadError
+  # probably means rubygems is too old or too new to have this class, and we don't care
+end
+
 ::Gem.clear_paths
 EOS
     end

--- a/spec/fixtures/appbundler-example-app/.bundle/config
+++ b/spec/fixtures/appbundler-example-app/.bundle/config
@@ -1,2 +1,2 @@
 ---
-BUNDLE_WITHOUT: something
+BUNDLE_WITHOUT: "something"


### PR DESCRIPTION
in at least rubygems 2.7.6 when two chef gems are installed (as an
example, but i think the problem is generalized to other gems with
two installed versions, but it repros nicely with two chef gems),
instead of pinning a version a bundler bug makes us explode with

/opt/chefdk/embedded/lib/ruby/site_ruby/2.4.0/rubygems/dependency.rb:284:in `matching_specs': uninitialized constant Gem::BundlerVersionFinder (NameError)

which is rubygems/rubygems#2196

this works around the bug by doing the require here, protected with
exception handling to not blow up on rubygems versions that don't
have this class.

once 2.7.7 / 2.8.0 is released this code should probably be
deleted (at the same time the exception means it shouldn't hurt
anything).

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>