### PR TITLE
Don't appbundle from within bundle exec

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -226,7 +226,6 @@ E
     # exists to make tests run correctly on travis.ci (which uses rvm).
     def env_sanitizer
       <<-EOS
-ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
 require "rubygems"
 
 begin
@@ -236,13 +235,15 @@ rescue LoadError
   # probably means rubygems is too old or too new to have this class, and we don't care
 end
 
-::Gem.clear_paths
+unless ENV["BUNDLE_GEMFILE"]
+  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+  ::Gem.clear_paths
 EOS
     end
 
     def runtime_activate
       @runtime_activate ||= begin
-        statements = runtime_dep_specs.map { |s| %Q{gem "#{s.name}", "= #{s.version}"} }
+        statements = runtime_dep_specs.map { |s| %Q{  gem "#{s.name}", "= #{s.version}"} }
         activate_code = ""
         activate_code << env_sanitizer << "\n"
         activate_code << statements.join("\n") << "\n"
@@ -258,9 +259,12 @@ EOS
       name, version = app_spec.name, app_spec.version
       bin_basename = File.basename(bin_file)
       <<-E
-gem "#{name}", "= #{version}"
+  gem "#{name}", "= #{version}"
+  spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
+else
+  spec = Gem::Specification.find_by_name("#{name}")
+end
 
-spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
 bin_file = spec.bin_file("#{bin_basename}")
 
 Kernel.load(bin_file)


### PR DESCRIPTION
Applying the appbundle binstubs from inside a wrapping bundle exec
is not a useful thing and just creates conflicts.

When invoked inside of a bundler just use the wrapping Gemfile and
activate the gems that are found in there.

closes #33

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>