### PR TITLE
Revert "Don't appbundle from within bundle exec"

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -226,6 +226,7 @@ E
     # exists to make tests run correctly on travis.ci (which uses rvm).
     def env_sanitizer
       <<-EOS
+ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
 require "rubygems"
 
 begin
@@ -235,15 +236,13 @@ rescue LoadError
   # probably means rubygems is too old or too new to have this class, and we don't care
 end
 
-unless ENV["BUNDLE_GEMFILE"]
-  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
-  ::Gem.clear_paths
+::Gem.clear_paths
 EOS
     end
 
     def runtime_activate
       @runtime_activate ||= begin
-        statements = runtime_dep_specs.map { |s| %Q{  gem "#{s.name}", "= #{s.version}"} }
+        statements = runtime_dep_specs.map { |s| %Q{gem "#{s.name}", "= #{s.version}"} }
         activate_code = ""
         activate_code << env_sanitizer << "\n"
         activate_code << statements.join("\n") << "\n"
@@ -259,12 +258,9 @@ EOS
       name, version = app_spec.name, app_spec.version
       bin_basename = File.basename(bin_file)
       <<-E
-  gem "#{name}", "= #{version}"
-  spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
-else
-  spec = Gem::Specification.find_by_name("#{name}")
-end
+gem "#{name}", "= #{version}"
 
+spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
 bin_file = spec.bin_file("#{bin_basename}")
 
 Kernel.load(bin_file)


### PR DESCRIPTION
So the problems with this are very annoying:

1.  Things like travis will set BUNDLE_GEMFILE but the user may not `bundle install` or `bundle exec` so we can't rely on that as a test to see if we're in bundler.

2.  We rely on `eval "$(/opt/chefdk/bin/chef shell-init bash)"` to clean up the rvm environment in travis.

- GEM_PATH + GEM_HOME are set by rvm and must be cleaned in order to run the shell-init command
- after shell-init is run GEM_PATH + GEM_HOME are set pointing at chefdk + the .chefdk dir 

The workflow that we would have to support is:

- use rvm and create an empty gemset
- `eval "$(/opt/chefdk/bin/chef shell-init bash)"` and reset the env vars <-- this relies on the binstubs to reset the env to even invoke the `chef` command.
- `/opt/chefdk/embedded/bin/chef --version` should work

Note that what people do is call embedded directly, that's not a typo there, so it bypasses the binstubs and just uses chefdk as a normal ruby.