### PR TITLE
Require ruby 2.3+ and loosen gem deps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 ### Issues Resolved
 
 [List any existing issues this PR resolves, or any Discourse or
-StackOverflow discussion that's relevant]
+StackOverflow discussions that are relevant]
 
 ### Check List
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
 rvm:
   - 2.3.8
   - 2.4.5
-  - 2.5.3
-  - 2.6
+  - 2.5.5
+  - 2.6.2
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ before_install:
   - gem install bundler || true
 
 rvm:
-  - 2.2.10
   - 2.3.8
   - 2.4.5
   - 2.5.3

--- a/appbundler.gemspec
+++ b/appbundler.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry"
 
-  spec.add_dependency "mixlib-shellout", "~> 2.0"
-  spec.add_dependency "mixlib-cli", "~> 1.4"
+  spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
+  spec.add_dependency "mixlib-cli", ">= 1.4", "< 3.0"
 end

--- a/appbundler.gemspec
+++ b/appbundler.gemspec
@@ -6,8 +6,8 @@ require "appbundler/version"
 Gem::Specification.new do |spec|
   spec.name          = "appbundler"
   spec.version       = Appbundler::VERSION
-  spec.authors       = ["Dan DeLeo"]
-  spec.email         = ["dan@chef.io"]
+  spec.authors       = ["Chef Software, Inc."]
+  spec.email         = ["info@chef.io"]
   spec.description   = %q{Extracts a dependency solution from bundler's Gemfile.lock to speed gem activation}
   spec.summary       = spec.description
   spec.homepage      = "https://github.com/chef/appbundler"

--- a/appbundler.gemspec
+++ b/appbundler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.2.0"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Remove support for EOL Ruby 2.2 and allow for newer releases of our gems