### PR TITLE
add --binstub-source option

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -136,6 +136,16 @@ module Appbundler
       end
     end
 
+    # This is used to copy the binstubs from the binstub source directory to the actual
+    # binstub location.
+    #
+    def copy_binstubs(binstubs_source)
+      gem_path = installed_spec.gem_dir
+      dst = "#{gem_path}/bin"
+      src = "#{gem_path}/#{binstubs_source}/*"
+      FileUtils.cp_r(Dir.glob(src), dst)
+    end
+
     # This is the implementation of the 3-arg version of writing the merged lockfiles,
     # when called with the 2-arg version it short-circuits, however, to the copy_bundler_env
     # version above.

--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -86,7 +86,7 @@ module Appbundler
     # of our appbundle calls.  But to ship ChefDK 2.0 we just do this.
     SHITLIST = [
       "github_changelog_generator",
-    ]
+    ].freeze
 
     # This is a check which is equivalent to asking if we are running 2-arg or 3-arg.  If
     # we have an "external_lockfile" that means the chef-dk omnibus Gemfile.lock, e.g.:
@@ -111,11 +111,11 @@ module Appbundler
     #
     def local_gemfile_lock_specs
       gemfile_lock_specs.map do |s|
-        #if SHITLIST.include?(s.name)
+        # if SHITLIST.include?(s.name)
         #  nil
-        #else
-          safe_resolve_local_gem(s)
-        #end
+        # else
+        safe_resolve_local_gem(s)
+        # end
       end.compact
     end
 
@@ -129,7 +129,7 @@ module Appbundler
       gem_path = installed_spec.gem_dir
       # If we're already using that directory, don't copy (it won't work anyway)
       return if gem_path == File.dirname(gemfile_lock)
-      FileUtils.install(gemfile_lock, gem_path, :mode => 0644)
+      FileUtils.install(gemfile_lock, gem_path, mode: 0644)
       if File.exist?(dot_bundle_dir) && File.directory?(dot_bundle_dir)
         FileUtils.cp_r(dot_bundle_dir, gem_path)
         FileUtils.chmod_R("ugo+rX", File.join(gem_path, ".bundle"))
@@ -165,7 +165,7 @@ module Appbundler
         locked_gems = {}
 
         gemfile_lock_specs.each do |s|
-          #next if SHITLIST.include?(s.name)
+          # next if SHITLIST.include?(s.name)
           spec = safe_resolve_local_gem(s)
           next if spec.nil?
 
@@ -207,7 +207,7 @@ module Appbundler
         end
 
         t.close
-        puts IO.read(t.path)  # debugging
+        puts IO.read(t.path) # debugging
         Dir.chdir(app_dir) do
           FileUtils.rm_f "#{app_dir}/Gemfile.lock"
           Bundler.with_clean_env do
@@ -218,7 +218,7 @@ module Appbundler
           FileUtils.mv t.path, "#{app_dir}/Gemfile"
         end
       end
-      return "#{app_dir}/Gemfile"
+      "#{app_dir}/Gemfile"
     end
 
     def write_executable_stubs
@@ -257,10 +257,10 @@ module Appbundler
 
     def batchfile_stub
       ruby_relpath_windows = ruby_relative_path.tr("/", '\\')
-      <<-E
-@ECHO OFF
-"%~dp0\\#{ruby_relpath_windows}" "%~dpn0" %*
-E
+      <<~E
+        @ECHO OFF
+        "%~dp0\\#{ruby_relpath_windows}" "%~dpn0" %*
+      E
     end
 
     # Relative path from #target_bin_dir to #ruby. This is used to
@@ -298,24 +298,24 @@ E
     # APPBUNDLER_ALLOW_RVM environment variable to "true". This feature
     # exists to make tests run correctly on travis.ci (which uses rvm).
     def env_sanitizer
-      <<-EOS
-require "rubygems"
+      <<~EOS
+        require "rubygems"
 
-begin
-  # this works around rubygems/rubygems#2196 and can be removed in rubygems > 2.7.6
-  require "rubygems/bundler_version_finder"
-rescue LoadError
-  # probably means rubygems is too old or too new to have this class, and we don't care
-end
+        begin
+          # this works around rubygems/rubygems#2196 and can be removed in rubygems > 2.7.6
+          require "rubygems/bundler_version_finder"
+        rescue LoadError
+          # probably means rubygems is too old or too new to have this class, and we don't care
+        end
 
-# avoid appbundling if we are definitely running within a Bundler bundle.
-# most likely the check for defined?(Bundler) is enough since we don't require
-# bundler above, but just for paranoia's sake also we test to see if Bundler is
-# really doing its thing or not.
-unless defined?(Bundler) && Bundler.instance_variable_defined?("@load")
-  ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
-  ::Gem.clear_paths
-EOS
+        # avoid appbundling if we are definitely running within a Bundler bundle.
+        # most likely the check for defined?(Bundler) is enough since we don't require
+        # bundler above, but just for paranoia's sake also we test to see if Bundler is
+        # really doing its thing or not.
+        unless defined?(Bundler) && Bundler.instance_variable_defined?("@load")
+          ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+          ::Gem.clear_paths
+      EOS
     end
 
     def runtime_activate
@@ -335,17 +335,17 @@ EOS
     def load_statement_for(bin_file)
       name, version = app_spec.name, app_spec.version
       bin_basename = File.basename(bin_file)
-      <<-E
-  gem "#{name}", "= #{version}"
-  spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
-else
-  spec = Gem::Specification.find_by_name("#{name}")
-end
+      <<~E
+          gem "#{name}", "= #{version}"
+          spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
+        else
+          spec = Gem::Specification.find_by_name("#{name}")
+        end
 
-bin_file = spec.bin_file("#{bin_basename}")
+        bin_file = spec.bin_file("#{bin_basename}")
 
-Kernel.load(bin_file)
-E
+        Kernel.load(bin_file)
+      E
     end
 
     def executables
@@ -423,12 +423,12 @@ E
       inaccessable_gems = inaccessable_git_sourced_gems
       return true if inaccessable_gems.empty?
 
-      message = <<-MESSAGE
-Application '#{name}' contains gems in the lockfile which are
-not accessible by rubygems. This usually occurs when you fetch gems from git in
-your Gemfile and do not install the same version of the gems beforehand.
+      message = <<~MESSAGE
+        Application '#{name}' contains gems in the lockfile which are
+        not accessible by rubygems. This usually occurs when you fetch gems from git in
+        your Gemfile and do not install the same version of the gems beforehand.
 
-MESSAGE
+      MESSAGE
 
       message << "The Gemfile.lock is located here:\n- #{gemfile_lock}\n\n"
 

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -6,54 +6,54 @@ module Appbundler
   class CLI
     include Mixlib::CLI
 
-    banner(<<-BANNER)
-* appbundler #{VERSION} *
+    banner(<<~BANNER)
+      * appbundler #{VERSION} *
 
-Usage: appbundler BUNDLE_DIR BINSTUB_DIR [GEM_NAME] [GEM_NAME] ...
+      Usage: appbundler BUNDLE_DIR BINSTUB_DIR [GEM_NAME] [GEM_NAME] ...
 
-  BUNDLE_DIR is the root directory to the bundle containing your app
-  BINSTUB_DIR is the directory where you want generated executables to be written
-  GEM_NAME is the name of a gem you want to appbundle. Default is the directory name
-           of BUNDLE_DIR (e.g. /src/chef -> chef)
+        BUNDLE_DIR is the root directory to the bundle containing your app
+        BINSTUB_DIR is the directory where you want generated executables to be written
+        GEM_NAME is the name of a gem you want to appbundle. Default is the directory name
+                 of BUNDLE_DIR (e.g. /src/chef -> chef)
 
-Your bundled application must already be gem installed.  Generated binstubs
-will point to the gem, not your working copy.
-BANNER
+      Your bundled application must already be gem installed.  Generated binstubs
+      will point to the gem, not your working copy.
+    BANNER
 
     # this is used by chef-dk, its probably not an external API, here be dragons
     option :without,
-      :long => "--without GROUPS",
-      :description => "Comma separated list of groups to exclude when building transitive Gemfile.locks (internal API)",
-      :proc => lambda { |o| o.split(/[\s,]+/) },
-      :default => []
+      long: "--without GROUPS",
+      description: "Comma separated list of groups to exclude when building transitive Gemfile.locks (internal API)",
+      proc: lambda { |o| o.split(/[\s,]+/) },
+      default: []
 
     option :binstubs_source,
-      :long => "--binstubs-source path/to/binstubs",
-      :description => "Path to binstubs within the gem to be moved into the bindir",
-      :default => nil
+      long: "--binstubs-source path/to/binstubs",
+      description: "Path to binstubs within the gem to be moved into the bindir",
+      default: nil
 
     option :extra_bin_files,
-      :long => "--extra-bin-files bin1,bin2",
-      :description => "Comma separated list of extra binstubs to wire up which are not listed in the gemspec",
-      :proc => lambda { |o| o.split(/[\s,]+/) },
-      :default => []
+      long: "--extra-bin-files bin1,bin2",
+      description: "Comma separated list of extra binstubs to wire up which are not listed in the gemspec",
+      proc: lambda { |o| o.split(/[\s,]+/) },
+      default: []
 
     option :version,
-      :short => "-v",
-      :long => "--version",
-      :description => "Show appbundler version",
-      :boolean => true,
-      :proc => lambda { |v| $stdout.puts("Appbundler Version: #{::Appbundler::VERSION}") },
-      :exit => 0
+      short: "-v",
+      long: "--version",
+      description: "Show appbundler version",
+      boolean: true,
+      proc: lambda { |v| $stdout.puts("Appbundler Version: #{::Appbundler::VERSION}") },
+      exit: 0
 
     option :help,
-      :short => "-h",
-      :long => "--help",
-      :description => "Show this message",
-      :on => :tail,
-      :boolean => true,
-      :show_options => true,
-      :exit => 0
+      short: "-h",
+      long: "--help",
+      description: "Show this message",
+      on: :tail,
+      boolean: true,
+      show_options: true,
+      exit: 0
 
     def self.run(argv)
       cli = new(argv)

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -27,6 +27,11 @@ BANNER
       :proc => lambda { |o| o.split(/[\s,]+/) },
       :default => []
 
+    option :binstubs_source,
+      :long => "--binstubs-source path/to/binstubs",
+      :description => "Path to binstubs within the gem to be moved into the bindir",
+      :default => nil
+
     option :extra_bin_files,
       :long => "--extra-bin-files bin1,bin2",
       :description => "Comma separated list of extra binstubs to wire up which are not listed in the gemspec",
@@ -111,6 +116,10 @@ BANNER
         end
         created_lockfile = app.write_merged_lockfiles(without: config[:without])
         $stdout.puts "Generated merged lockfile at #{created_lockfile}" if created_lockfile
+        if config[:binstubs_source]
+          app.copy_binstubs(config[:binstubs_source])
+          $stdout.puts "Copied binstubs"
+        end
       end
     end
 

--- a/lib/appbundler/version.rb
+++ b/lib/appbundler/version.rb
@@ -1,3 +1,3 @@
 module Appbundler
-  VERSION = "0.12.3"
+  VERSION = "0.12.3".freeze
 end

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -11,15 +11,15 @@ describe Appbundler do
   end
 
   def double_spec(name, version, dep_names)
-    deps = dep_names.map { |n| double("Bundler::Dependency #{n}", :name => n.to_s) }
+    deps = dep_names.map { |n| double("Bundler::Dependency #{n}", name: n.to_s) }
     source = double("Bundler::Source::Rubygems")
-    spec = double("Bundler::LazySpecification '#{name}'", :name => name.to_s, :version => version, :dependencies => deps, :source => source)
+    spec = double("Bundler::LazySpecification '#{name}'", name: name.to_s, version: version, dependencies: deps, source: source)
     all_specs << spec
     spec
   end
 
   def shellout!(cmd)
-    s = Mixlib::ShellOut.new(cmd, :env => { "RUBYOPT" => nil, "BUNDLE_GEMFILE" => nil, "APPBUNDLER_ALLOW_RVM" => "true" })
+    s = Mixlib::ShellOut.new(cmd, env: { "RUBYOPT" => nil, "BUNDLE_GEMFILE" => nil, "APPBUNDLER_ALLOW_RVM" => "true" })
     s.run_command
     s.error!
     s
@@ -99,23 +99,23 @@ describe Appbundler do
     end
 
     it "locks the main app's gem via rubygems, and loads the proper binary" do
-      expected_loading_code = <<-CODE
-gem "app", "= 1.0.0"
+      expected_loading_code = <<~CODE
+        gem "app", "= 1.0.0"
 
-spec = Gem::Specification.find_by_name("app", "= 1.0.0")
-bin_file = spec.bin_file("foo")
+        spec = Gem::Specification.find_by_name("app", "= 1.0.0")
+        bin_file = spec.bin_file("foo")
 
-Kernel.load(bin_file)
-CODE
+        Kernel.load(bin_file)
+      CODE
       expect(app.load_statement_for(bin_path)).to eq(expected_loading_code)
     end
 
     it "generates code to override GEM_HOME and GEM_PATH (e.g., rvm)" do
-      expected = <<-EOS
-ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
-require "rubygems"
-::Gem.clear_paths
-EOS
+      expected = <<~EOS
+        ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+        require "rubygems"
+        ::Gem.clear_paths
+      EOS
 
       expect(app.env_sanitizer).to eq(expected)
       expect(app.runtime_activate).to include(expected)
@@ -134,10 +134,10 @@ EOS
       end
 
       it "generates batchfile stub code" do
-        expected_batch_code = <<-E
-@ECHO OFF
-"%~dp0\\..\\embedded\\bin\\ruby.exe" "%~dpn0" %*
-E
+        expected_batch_code = <<~E
+          @ECHO OFF
+          "%~dp0\\..\\embedded\\bin\\ruby.exe" "%~dpn0" %*
+        E
         expect(app.batchfile_stub).to eq(expected_batch_code)
       end
 
@@ -155,8 +155,8 @@ E
 
       # Ensure that the behavior we emulate in our stubs is correct:
       it "sanity checks rubygems behavior" do
-        expect { Gem::Specification.find_by_name("there-is-no-such-gem-named-this", "= 999.999.999") }.
-          to raise_error(Gem::LoadError)
+        expect { Gem::Specification.find_by_name("there-is-no-such-gem-named-this", "= 999.999.999") }
+          .to raise_error(Gem::LoadError)
       end
 
       context "and the gems are not accessible by rubygems" do
@@ -238,123 +238,123 @@ E
 
     it "generates runtime activation code for the app" do
       expected_gem_activates = if windows?
-                                 <<-E
-ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
-require "rubygems"
-::Gem.clear_paths
+                                 <<~E
+                                   ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+                                   require "rubygems"
+                                   ::Gem.clear_paths
 
-gem "chef", "= 12.4.1"
-gem "chef-config", "= 12.4.1"
-gem "mixlib-config", "= 2.2.1"
-gem "mixlib-shellout", "= 2.2.0"
-gem "win32-process", "= 0.7.5"
-gem "ffi", "= 1.9.10"
-gem "chef-zero", "= 4.3.0"
-gem "ffi-yajl", "= 2.2.2"
-gem "libyajl2", "= 1.2.0"
-gem "hashie", "= 2.1.2"
-gem "mixlib-log", "= 1.6.0"
-gem "rack", "= 1.6.4"
-gem "uuidtools", "= 2.1.5"
-gem "diff-lcs", "= 1.2.5"
-gem "erubis", "= 2.7.0"
-gem "highline", "= 1.7.3"
-gem "mixlib-authentication", "= 1.3.0"
-gem "mixlib-cli", "= 1.5.0"
-gem "net-ssh", "= 2.9.2"
-gem "net-ssh-multi", "= 1.2.1"
-gem "net-ssh-gateway", "= 1.2.0"
-gem "ohai", "= 8.5.1"
-gem "ipaddress", "= 0.8.0"
-gem "mime-types", "= 2.6.1"
-gem "rake", "= 10.1.1"
-gem "systemu", "= 2.6.5"
-gem "wmi-lite", "= 1.0.0"
-gem "plist", "= 3.1.0"
-gem "pry", "= 0.9.12.6"
-gem "coderay", "= 1.1.0"
-gem "method_source", "= 0.8.2"
-gem "slop", "= 3.4.7"
-gem "win32console", "= 1.3.2"
-gem "rspec-core", "= 3.3.2"
-gem "rspec-support", "= 3.3.0"
-gem "rspec-expectations", "= 3.3.1"
-gem "rspec-mocks", "= 3.3.2"
-gem "rspec_junit_formatter", "= 0.2.3"
-gem "builder", "= 3.2.2"
-gem "serverspec", "= 2.23.1"
-gem "multi_json", "= 1.11.2"
-gem "rspec", "= 3.3.0"
-gem "rspec-its", "= 1.2.0"
-gem "specinfra", "= 2.43.3"
-gem "net-scp", "= 1.2.1"
-gem "net-telnet", "= 0.1.1"
-gem "sfl", "= 2.2"
-gem "syslog-logger", "= 1.6.8"
-gem "win32-api", "= 1.5.3"
-gem "win32-dir", "= 0.5.0"
-gem "win32-event", "= 0.6.1"
-gem "win32-ipc", "= 0.6.6"
-gem "win32-eventlog", "= 0.6.3"
-gem "win32-mmap", "= 0.4.1"
-gem "win32-mutex", "= 0.4.2"
-gem "win32-service", "= 0.8.6"
-gem "windows-api", "= 0.4.4"
-gem "windows-pr", "= 1.2.4"
-E
+                                   gem "chef", "= 12.4.1"
+                                   gem "chef-config", "= 12.4.1"
+                                   gem "mixlib-config", "= 2.2.1"
+                                   gem "mixlib-shellout", "= 2.2.0"
+                                   gem "win32-process", "= 0.7.5"
+                                   gem "ffi", "= 1.9.10"
+                                   gem "chef-zero", "= 4.3.0"
+                                   gem "ffi-yajl", "= 2.2.2"
+                                   gem "libyajl2", "= 1.2.0"
+                                   gem "hashie", "= 2.1.2"
+                                   gem "mixlib-log", "= 1.6.0"
+                                   gem "rack", "= 1.6.4"
+                                   gem "uuidtools", "= 2.1.5"
+                                   gem "diff-lcs", "= 1.2.5"
+                                   gem "erubis", "= 2.7.0"
+                                   gem "highline", "= 1.7.3"
+                                   gem "mixlib-authentication", "= 1.3.0"
+                                   gem "mixlib-cli", "= 1.5.0"
+                                   gem "net-ssh", "= 2.9.2"
+                                   gem "net-ssh-multi", "= 1.2.1"
+                                   gem "net-ssh-gateway", "= 1.2.0"
+                                   gem "ohai", "= 8.5.1"
+                                   gem "ipaddress", "= 0.8.0"
+                                   gem "mime-types", "= 2.6.1"
+                                   gem "rake", "= 10.1.1"
+                                   gem "systemu", "= 2.6.5"
+                                   gem "wmi-lite", "= 1.0.0"
+                                   gem "plist", "= 3.1.0"
+                                   gem "pry", "= 0.9.12.6"
+                                   gem "coderay", "= 1.1.0"
+                                   gem "method_source", "= 0.8.2"
+                                   gem "slop", "= 3.4.7"
+                                   gem "win32console", "= 1.3.2"
+                                   gem "rspec-core", "= 3.3.2"
+                                   gem "rspec-support", "= 3.3.0"
+                                   gem "rspec-expectations", "= 3.3.1"
+                                   gem "rspec-mocks", "= 3.3.2"
+                                   gem "rspec_junit_formatter", "= 0.2.3"
+                                   gem "builder", "= 3.2.2"
+                                   gem "serverspec", "= 2.23.1"
+                                   gem "multi_json", "= 1.11.2"
+                                   gem "rspec", "= 3.3.0"
+                                   gem "rspec-its", "= 1.2.0"
+                                   gem "specinfra", "= 2.43.3"
+                                   gem "net-scp", "= 1.2.1"
+                                   gem "net-telnet", "= 0.1.1"
+                                   gem "sfl", "= 2.2"
+                                   gem "syslog-logger", "= 1.6.8"
+                                   gem "win32-api", "= 1.5.3"
+                                   gem "win32-dir", "= 0.5.0"
+                                   gem "win32-event", "= 0.6.1"
+                                   gem "win32-ipc", "= 0.6.6"
+                                   gem "win32-eventlog", "= 0.6.3"
+                                   gem "win32-mmap", "= 0.4.1"
+                                   gem "win32-mutex", "= 0.4.2"
+                                   gem "win32-service", "= 0.8.6"
+                                   gem "windows-api", "= 0.4.4"
+                                   gem "windows-pr", "= 1.2.4"
+                                 E
                                else
-                                 <<-E
-ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
-require "rubygems"
-::Gem.clear_paths
+                                 <<~E
+                                   ENV["GEM_HOME"] = ENV["GEM_PATH"] = nil unless ENV["APPBUNDLER_ALLOW_RVM"] == "true"
+                                   require "rubygems"
+                                   ::Gem.clear_paths
 
-gem "chef", "= 12.4.1"
-gem "chef-config", "= 12.4.1"
-gem "mixlib-config", "= 2.2.1"
-gem "mixlib-shellout", "= 2.2.0"
-gem "chef-zero", "= 4.3.0"
-gem "ffi-yajl", "= 2.2.2"
-gem "libyajl2", "= 1.2.0"
-gem "hashie", "= 2.1.2"
-gem "mixlib-log", "= 1.6.0"
-gem "rack", "= 1.6.4"
-gem "uuidtools", "= 2.1.5"
-gem "diff-lcs", "= 1.2.5"
-gem "erubis", "= 2.7.0"
-gem "highline", "= 1.7.3"
-gem "mixlib-authentication", "= 1.3.0"
-gem "mixlib-cli", "= 1.5.0"
-gem "net-ssh", "= 2.9.2"
-gem "net-ssh-multi", "= 1.2.1"
-gem "net-ssh-gateway", "= 1.2.0"
-gem "ohai", "= 8.5.1"
-gem "ffi", "= 1.9.10"
-gem "ipaddress", "= 0.8.0"
-gem "mime-types", "= 2.6.1"
-gem "rake", "= 10.1.1"
-gem "systemu", "= 2.6.5"
-gem "wmi-lite", "= 1.0.0"
-gem "plist", "= 3.1.0"
-gem "pry", "= 0.9.12.6"
-gem "coderay", "= 1.1.0"
-gem "method_source", "= 0.8.2"
-gem "slop", "= 3.4.7"
-gem "rspec-core", "= 3.3.2"
-gem "rspec-support", "= 3.3.0"
-gem "rspec-expectations", "= 3.3.1"
-gem "rspec-mocks", "= 3.3.2"
-gem "rspec_junit_formatter", "= 0.2.3"
-gem "builder", "= 3.2.2"
-gem "serverspec", "= 2.23.1"
-gem "multi_json", "= 1.11.2"
-gem "rspec", "= 3.3.0"
-gem "rspec-its", "= 1.2.0"
-gem "specinfra", "= 2.43.3"
-gem "net-scp", "= 1.2.1"
-gem "net-telnet", "= 0.1.1"
-gem "sfl", "= 2.2"
-gem "syslog-logger", "= 1.6.8"
-E
+                                   gem "chef", "= 12.4.1"
+                                   gem "chef-config", "= 12.4.1"
+                                   gem "mixlib-config", "= 2.2.1"
+                                   gem "mixlib-shellout", "= 2.2.0"
+                                   gem "chef-zero", "= 4.3.0"
+                                   gem "ffi-yajl", "= 2.2.2"
+                                   gem "libyajl2", "= 1.2.0"
+                                   gem "hashie", "= 2.1.2"
+                                   gem "mixlib-log", "= 1.6.0"
+                                   gem "rack", "= 1.6.4"
+                                   gem "uuidtools", "= 2.1.5"
+                                   gem "diff-lcs", "= 1.2.5"
+                                   gem "erubis", "= 2.7.0"
+                                   gem "highline", "= 1.7.3"
+                                   gem "mixlib-authentication", "= 1.3.0"
+                                   gem "mixlib-cli", "= 1.5.0"
+                                   gem "net-ssh", "= 2.9.2"
+                                   gem "net-ssh-multi", "= 1.2.1"
+                                   gem "net-ssh-gateway", "= 1.2.0"
+                                   gem "ohai", "= 8.5.1"
+                                   gem "ffi", "= 1.9.10"
+                                   gem "ipaddress", "= 0.8.0"
+                                   gem "mime-types", "= 2.6.1"
+                                   gem "rake", "= 10.1.1"
+                                   gem "systemu", "= 2.6.5"
+                                   gem "wmi-lite", "= 1.0.0"
+                                   gem "plist", "= 3.1.0"
+                                   gem "pry", "= 0.9.12.6"
+                                   gem "coderay", "= 1.1.0"
+                                   gem "method_source", "= 0.8.2"
+                                   gem "slop", "= 3.4.7"
+                                   gem "rspec-core", "= 3.3.2"
+                                   gem "rspec-support", "= 3.3.0"
+                                   gem "rspec-expectations", "= 3.3.1"
+                                   gem "rspec-mocks", "= 3.3.2"
+                                   gem "rspec_junit_formatter", "= 0.2.3"
+                                   gem "builder", "= 3.2.2"
+                                   gem "serverspec", "= 2.23.1"
+                                   gem "multi_json", "= 1.11.2"
+                                   gem "rspec", "= 3.3.0"
+                                   gem "rspec-its", "= 1.2.0"
+                                   gem "specinfra", "= 2.43.3"
+                                   gem "net-scp", "= 1.2.1"
+                                   gem "net-telnet", "= 0.1.1"
+                                   gem "sfl", "= 2.2"
+                                   gem "syslog-logger", "= 1.6.8"
+                                 E
                                end
       expect(app.runtime_activate).to include(expected_gem_activates)
     end
@@ -391,8 +391,8 @@ E
       binary_2 = File.join(target_bindir, "app-binary-2")
       expect(File.exist?(binary_1)).to be(true)
       expect(File.exist?(binary_2)).to be(true)
-      expect(File.executable?(binary_1) || File.exists?(binary_1 + ".bat")).to be(true)
-      expect(File.executable?(binary_1) || File.exists?(binary_1 + ".bat")).to be(true)
+      expect(File.executable?(binary_1) || File.exist?(binary_1 + ".bat")).to be(true)
+      expect(File.executable?(binary_1) || File.exist?(binary_1 + ".bat")).to be(true)
       expect(shellout!(binary_1).stdout.strip).to eq("binary 1 ran")
       expect(shellout!(binary_2).stdout.strip).to eq("binary 2 ran")
     end
@@ -401,7 +401,7 @@ E
       spec = Gem::Specification.find_by_name("appbundler-example-app", "= 1.0.0")
       gem_path = spec.gem_dir
       app.copy_bundler_env
-      expect(File.exists?(File.join(gem_path, "Gemfile.lock"))).to be(true)
+      expect(File.exist?(File.join(gem_path, "Gemfile.lock"))).to be(true)
     end
 
     it "copies over .bundler to the gem directory" do
@@ -409,7 +409,7 @@ E
       gem_path = spec.gem_dir
       app.copy_bundler_env
       expect(File.directory?(File.join(gem_path, ".bundle"))).to be(true)
-      expect(File.exists?(File.join(gem_path, ".bundle/config"))).to be(true)
+      expect(File.exist?(File.join(gem_path, ".bundle/config"))).to be(true)
     end
     context "and the executable is symlinked to a different directory", :not_supported_on_windows do
 
@@ -449,10 +449,10 @@ E
       end
 
       let(:expected_batch_code) do
-        <<-E
-@ECHO OFF
-"%~dp0\\#{expected_ruby_relpath}" "%~dpn0" %*
-E
+        <<~E
+          @ECHO OFF
+          "%~dp0\\#{expected_ruby_relpath}" "%~dpn0" %*
+        E
       end
 
       before do

--- a/spec/fixtures/appbundler-example-app/lib/example_app.rb
+++ b/spec/fixtures/appbundler-example-app/lib/example_app.rb
@@ -1,3 +1,3 @@
 module ExampleApp
-  IT_WORKS = "yes"
+  IT_WORKS = "yes".freeze
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ def windows?
 end
 
 RSpec.configure do |c|
-  c.filter_run :focus => true
+  c.filter_run focus: true
   c.run_all_when_everything_filtered = true
   c.filter_run_excluding(not_supported_on_windows: true) if windows?
 end


### PR DESCRIPTION
This is used to copy binstubs from some stashed ("source") location into the bin directory in the gem_dir.

This is here in appbundler because it makes it easier to re-appbundle and keeps all the logic for the mangling we do of the gem to "prep" it for omnibus in one location.

This makes it easy to do things like the kitchen-tests in chef/chef which need to patch in the new gem and call appbundle-updater and also need this step (it made more sense to do this here than in appbundle-updater or in the kitchen configuration there).

This is now growing enough in terms of configuration state that I'm wondering if we just shouldn't have an Appbundler.rb file in the root of the gem/project with all the configuration.