### PR TITLE
revert the --binstubs-source and --extra-bin-flags

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -17,10 +17,9 @@ module Appbundler
     attr_reader :bundle_path
     attr_reader :target_bin_dir
     attr_reader :name
-    attr_reader :extra_bin_files
 
-    # The bundle_path is always the path to the directory containing the Gemfile.lock
-    # being used, e.g.  /var/cache/omnibus/src/chef/chefor whatever.  If
+    # The bundle_path is always the path to the Gemfile.lock being used, e.g.
+    # /var/cache/omnibus/src/chef/chef-14.10.9/Gemfile.lock or whatever.  If
     # the name if the gem is not set then we behave like old style 2-arg appbundling
     # where the gem we are appbundling is in the gemspec in that directory.
     #
@@ -31,11 +30,10 @@ module Appbundler
     # @param bundle_path [String] the directory path of the Gemfile.lock
     # @param target_bin_dir [String] the binstub dir, e.g. /opt/chefdk/bin
     # @param name [String] name of the gem
-    def initialize(bundle_path, target_bin_dir, name, extra_bin_files = [])
+    def initialize(bundle_path, target_bin_dir, name)
       @bundle_path = bundle_path
       @target_bin_dir = target_bin_dir
       @name = name
-      @extra_bin_files = extra_bin_files
     end
 
     # For the 2-arg version this is the gemfile in the omnibus build directory:
@@ -134,16 +132,6 @@ module Appbundler
         FileUtils.cp_r(dot_bundle_dir, gem_path)
         FileUtils.chmod_R("ugo+rX", File.join(gem_path, ".bundle"))
       end
-    end
-
-    # This is used to copy the binstubs from the binstub source directory to the actual
-    # binstub location.
-    #
-    def copy_binstubs(binstubs_source)
-      gem_path = installed_spec.gem_dir
-      dst = "#{gem_path}/bin"
-      src = File.join(bundle_path, binstubs_source, "*")
-      FileUtils.cp_r(Dir.glob(src), dst)
     end
 
     # This is the implementation of the 3-arg version of writing the merged lockfiles,
@@ -349,7 +337,8 @@ module Appbundler
     end
 
     def executables
-      installed_spec.executables.map { |e| installed_spec.bin_file(e) } + extra_bin_files
+      spec = installed_spec
+      spec.executables.map { |e| spec.bin_file(e) }
     end
 
     def runtime_dep_specs

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -27,17 +27,6 @@ module Appbundler
       proc: lambda { |o| o.split(/[\s,]+/) },
       default: []
 
-    option :binstubs_source,
-      long: "--binstubs-source path/to/binstubs",
-      description: "Path to binstubs within the gem to be moved into the bindir",
-      default: nil
-
-    option :extra_bin_files,
-      long: "--extra-bin-files bin1,bin2",
-      description: "Comma separated list of extra binstubs to wire up which are not listed in the gemspec",
-      proc: lambda { |o| o.split(/[\s,]+/) },
-      default: []
-
     option :version,
       short: "-v",
       long: "--version",
@@ -109,17 +98,13 @@ module Appbundler
 
     def run
       gems.each do |g|
-        app = App.new(bundle_path, bin_path, g, config[:extra_bin_files])
+        app = App.new(bundle_path, bin_path, g)
         created_stubs = app.write_executable_stubs
         created_stubs.each do |real_executable_path, stub_path|
           $stdout.puts "Generated binstub #{stub_path} => #{real_executable_path}"
         end
         created_lockfile = app.write_merged_lockfiles(without: config[:without])
         $stdout.puts "Generated merged lockfile at #{created_lockfile}" if created_lockfile
-        if config[:binstubs_source]
-          app.copy_binstubs(config[:binstubs_source])
-          $stdout.puts "Copied binstubs"
-        end
       end
     end
 


### PR DESCRIPTION
This approach wound up getting abandoned as not being fruitful so
nothing is now going to use this code, so the features now go
away.
