### PR TITLE
Warn on unresolved specs

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -330,6 +330,11 @@ module Appbundler
           spec = Gem::Specification.find_by_name("#{name}")
         end
 
+        unless Gem::Specification.unresolved_deps.empty?
+          $stderr.puts "APPBUNDLER WARNING: unresolved deps are CRITICAL performance bug, this MUST be fixed"
+          Gem::Specification.reset
+        end
+
         bin_file = spec.bin_file("#{bin_basename}")
 
         Kernel.load(bin_file)


### PR DESCRIPTION
These produce horrible perf degredation in rubygems internally:

https://github.com/rubygems/rubygems/issues/2761

Due to appbundler this "should" not happen, but due to:

https://github.com/chef/appbundler/commit/f01aea099ba3100e546a5ee315abc2a0e6d8878c

And due to ruby now shipping with bundler, we were getting two versions
of bundler and an unresolved spec, and therefore rubygems had
significant performance issues.  All that is required is correctly
activating bundler in the appbundler binstub and the spec becomes
resolved and the perf issues go away.

This commit just adds some warning about the issue so that people report
it, with a clear bit of text to not just ignore it.
