### PR TITLE
force bundler activation

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -325,6 +325,7 @@ module Appbundler
       bin_basename = File.basename(bin_file)
       <<~E
           gem "#{name}", "= #{version}"
+          gem "bundler" # force activation of bundler to avoid unresolved specs if there are multiple bundler versions
           spec = Gem::Specification.find_by_name("#{name}", "= #{version}")
         else
           spec = Gem::Specification.find_by_name("#{name}")


### PR DESCRIPTION
after we've activated all the other gems, force bundler activation.

since we're appbundling we've already activated all the gems and have
all the constraints loaded.  but bundler will not put bundler in a
Gemfile.lock due to bundler-ception issues.  we also do not want to
read and pin the version of bundler which is used to BUILD the lockfile
since that isn't necessarily the bundler version which omnibus will
install.

but once we're done we can force-activate bundler to resolve any
possible unresolved spec.

eventually we could be mildly smarter here if we need to and only do
this if ther are unresolved specs and if the unresolved spec is
bundler, but doing it all the time should be simple+safe.

(and since we've always installed bundler and bundler is in ruby now i can't see how activating it would go wrong here....)