### PR TITLE
Don't ship readme / hidden files in the artifact

### DIFF
--- a/appbundler.gemspec
+++ b/appbundler.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/chef/appbundler"
   spec.license       = "Apache-2.0"
 
-  spec.files         = `git ls-files`.split($/).select { |x| !/^\./.match(x) }
+  spec.files         = Dir.glob("{bin,lib,spec}/**/*").reject { |f| File.directory?(f) } + %w{ LICENSE appbundler.gemspec Rakefile Gemfile }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -100,21 +100,18 @@ describe Appbundler do
 
     it "locks the main app's gem via rubygems, and loads the proper binary" do
       expected_loading_code = <<~CODE
-        gem "app", "= 1.0.0"
-        gem "bundler" # force activation of bundler to avoid unresolved specs if there are multiple bundler versions
-        spec = Gem::Specification.find_by_name("app", "= 1.0.0")
-      else
-        spec = Gem::Specification.find_by_name("app")
-      end
-
-      unless Gem::Specification.unresolved_deps.empty?
-        $stderr.puts "APPBUNDLER WARNING: unresolved deps are CRITICAL performance bug, this MUST be fixed"
-        Gem::Specification.reset
-      end
-
-      bin_file = spec.bin_file("foo")
-
-      Kernel.load(bin_file)
+          gem "app", "= 1.0.0"
+          gem "bundler" # force activation of bundler to avoid unresolved specs if there are multiple bundler versions
+          spec = Gem::Specification.find_by_name("app", "= 1.0.0")
+        else
+          spec = Gem::Specification.find_by_name("app")
+        end
+         unless Gem::Specification.unresolved_deps.empty?
+          $stderr.puts "APPBUNDLER WARNING: unresolved deps are CRITICAL performance bug, this MUST be fixed"
+          Gem::Specification.reset
+        end
+         bin_file = spec.bin_file("foo")
+         Kernel.load(bin_file)
       CODE
       expect(app.load_statement_for(bin_path)).to eq(expected_loading_code)
     end


### PR DESCRIPTION
Slim down the install size of the gem slightly and takes 5k off the artifact size.

Signed-off-by: Tim Smith <tsmith@chef.io>