### PR TITLE
Substitute require for require_relative

### DIFF
--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -1,5 +1,5 @@
-require "appbundler/version"
-require "appbundler/app"
+require_relative "version"
+require_relative "app"
 require "mixlib/cli"
 
 module Appbundler


### PR DESCRIPTION
require_relative is significantly faster and should be used when available.

Signed-off-by: Tim Smith <tsmith@chef.io>