### PR TITLE
Changes for require openssl ahead of time to avoid fingerprint mismatch…

### DIFF
--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -289,6 +289,12 @@ module Appbundler
       <<~EOS
         require "rubygems"
 
+        # this works around OpenSSL FIPS fingerprint matching issue where
+        # it expects to be loaded in image base known at compile time. We
+        # load OpenSSL early so that the shared library gets loaded in its
+        # preferred image base address
+        require "openssl"
+
         begin
           # this works around rubygems/rubygems#2196 and can be removed in rubygems > 2.7.6
           require "rubygems/bundler_version_finder"

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -120,6 +120,12 @@ describe Appbundler do
       expected = <<~EOS
         require "rubygems"
 
+        # this works around OpenSSL FIPS fingerprint matching issue where
+        # it expects to be loaded in image base known at compile time. We
+        # load OpenSSL early so that the shared library gets loaded in its
+        # preferred image base address
+        require "openssl"
+
         begin
           # this works around rubygems/rubygems#2196 and can be removed in rubygems > 2.7.6
           require "rubygems/bundler_version_finder"


### PR DESCRIPTION
Signed-off-by: smriti <sgarg@msystechnologies.com>

Load `openssl` early during initialization as a workaround against `Openssl FIPS fingerprint mismatch` issue

## Description
OpenSSL library implements in-memory integrity verificiation as part of its enabling of FIPS mode. The integrity check basically computes an in-memory checksum and compares it with its compile time known "good" value.

On Windows, this works great if libeay32.dll is loaded in its desired base address set at compile time. This holds true if we run IRB and load openssl early. For example:

```
irb> require 'openssl'
irb> OpenSSL.fips_mode = true
```
This works fine.
However, FIPS mode fails due to fingerprint mismatch if we do:
```
irb> require 'chef'
irb> require 'openssl'
irb> OpenSSL.fips_mode = true   # Raises exception
```
This happens because when chef is loaded, it introduces dependencies that forces libeay32.dll to a different base address than what is set at compile time. Due to this, FIPS mode in-memory fingerprint verification fails.

The problem lies in OpenSSL legacy FIPS implementation and how it performs in-memory integrity verification i.e. based on compile time address. This is broken because OS dynamic linker do not guarantee a DLL to be always loaded in its desired base address.

Workaround:
Load `openssl` early in `chef-client` before loading `chef` gem.

References:
https://bz.apache.org/bugzilla/show_bug.cgi?id=55113
https://github.com/openssl/openssl/commit/086e32a6c7df4588834bc4d033a00382fd313b58
https://github.com/openssl/openssl/blob/086e32a6c7df4588834bc4d033a00382fd313b58/crypto/o_fips.c
https://wiki.openssl.org/index.php/Fipsld_and_C%2B%2B
https://github.com/openssl/openssl/blob/1a4d93bfb505b548aa6fa4ce0ffa0c6b11e856ed/fips/fips_premain.c

## Related Issue
https://github.com/chef/chef/issues/11743 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
