### PR TITLE
Remove support for EOL Ruby 2.4

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,28 +1,44 @@
-steps:
+---
+expeditor:
+  cached_folders:
+    - vendor
+  defaults:
+    buildkite:
+      retry:
+        automatic:
+          limit: 1
+      timeout_in_minutes: 30
 
-- label: run-lint-and-specs-ruby-2.4
-  command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.4-stretch
+steps:
 
 - label: run-lint-and-specs-ruby-2.5
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake
+    - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.5-stretch
+        image: ruby:2.5-buster
 
 - label: run-lint-and-specs-ruby-2.6
   command:
-    - bundle install --jobs=7 --retry=3 --without docs debug
-    - bundle exec rake
+    - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
-        image: ruby:2.6-stretch
+        image: ruby:2.6-buster
+
+- label: run-lint-and-specs-ruby-2.7
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:2.7-buster
+
+- label: run-lint-and-specs-ruby-3.0
+  command:
+    - .expeditor/run_linux_tests.sh rake
+  expeditor:
+    executor:
+      docker:
+        image: ruby:3.0-buster

--- a/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/BUG_TEMPLATE.md
@@ -1,7 +1,7 @@
 ---
 name: � Bug Report
 about: If something isn't working as expected �.
-labels: "Status: Untriaged"
+labels: "Status: Untriaged, Type: Bug"
 ---
 
 # Version:

--- a/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
+++ b/.github/ISSUE_TEMPLATE/DESIGN_PROPOSAL.md
@@ -1,7 +1,7 @@
 ---
 name: Design Proposal
 about: I have a significant change I would like to propose and discuss before starting
-labels: "Status: Untriaged"
+labels: "Status: Untriaged, Type: Design Proposal"
 ---
 
 ### When a Change Needs a Design Proposal

--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,6 @@ source "https://rubygems.org"
 
 gemspec
 
-group :docs do
-  gem "yard"
-  gem "redcarpet"
-  gem "github-markup"
-end
-
 group :test do
   gem "chefstyle"
   gem "rspec", "~> 3.0"
@@ -21,8 +15,7 @@ group :debug do
   gem "rb-readline"
 end
 
-instance_eval(ENV["GEMFILE_MOD"]) if ENV["GEMFILE_MOD"]
-
-# If you want to load debugging tools into the bundle exec sandbox,
-# add these additional dependencies into Gemfile.local
-eval_gemfile(__FILE__ + ".local") if File.exist?(__FILE__ + ".local")
+if Gem.ruby_version.to_s.start_with?("2.5")
+  # 16.7.23 required ruby 2.6+
+  gem "chef-utils", "< 16.7.23" # TODO: remove when we drop ruby 2.5
+end

--- a/Rakefile
+++ b/Rakefile
@@ -23,13 +23,6 @@ rescue LoadError
   puts "chefstyle gem is not installed. bundle install first to make sure all dependencies are installed."
 end
 
-begin
-  require "yard"
-  YARD::Rake::YardocTask.new(:docs)
-rescue LoadError
-  puts "yard is not available. bundle install first to make sure all dependencies are installed."
-end
-
 task :console do
   require "irb"
   require "irb/completion"

--- a/appbundler.gemspec
+++ b/appbundler.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "mixlib-shellout", ">= 2.0", "< 4.0"
   spec.add_dependency "mixlib-cli", ">= 1.4", "< 3.0"


### PR DESCRIPTION
Ruby 2.4 is no longer a supported Ruby release.

Signed-off-by: Tim Smith <tsmith@chef.io>