### PR TITLE
CHEF-25994 - Replace CODE_OF_CONDUCT.md file 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,1 +1,3 @@
-Please refer to the Chef Community Code of Conduct at https://www.chef.io/code-of-conduct/
+# Chef Code of Conduct
+
+Participants in this project must adhere to the [Chef Code of Conduct](https://chef.github.io/chef-oss-practices/policies/code-of-conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,3 @@
-Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md
+# Contributing to a Progress Chef Infra Client Project
+
+Thanks you for your interest in contribuing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
 # Contributing to a Progress Chef Infra Client Project
 
-Thanks you for your interest in contribuing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).
+Thank you for your interest in contributing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,1 @@
-# Contributing to a Progress Chef Infra Client Project
-
-Thank you for your interest in contributing to this project! It is part of the larger Progress Chef Infra Client project. Contribution guidelines can be found at [Contributing to Progress Chef Infra Client](https://chef.github.io/chef-oss-practices/projects/chef/contributing/).
-
+Please refer to https://github.com/chef/chef/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
As part of the [repo standardization effort](https://github.com/chef-boneyard/oss-repo-standardization-2025) we are standardizing all repos to have a standard CODE_OF_CONDUCT.md file that points to the main Chef Code of Conduct. This is not intended to be a change in policy, but rather an administrative change.