### PR TITLE
TEST-123 Add Progress copyright notices to source files - copyright_prepend

### DIFF
--- a/lib/appbundler.rb
+++ b/lib/appbundler.rb
@@ -1,3 +1,4 @@
+# Copyright (C) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 
 module Appbundler
 end

--- a/lib/appbundler/app.rb
+++ b/lib/appbundler/app.rb
@@ -1,3 +1,4 @@
+# Copyright (C) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 require "bundler"
 require "fileutils"
 require "mixlib/shellout"

--- a/lib/appbundler/cli.rb
+++ b/lib/appbundler/cli.rb
@@ -1,3 +1,4 @@
+# Copyright (C) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 require_relative "version"
 require_relative "app"
 require "mixlib/cli"

--- a/lib/appbundler/version.rb
+++ b/lib/appbundler/version.rb
@@ -1,3 +1,4 @@
+# Copyright (C) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 module Appbundler
   VERSION = "0.13.5".freeze
 end

--- a/spec/appbundler/app_spec.rb
+++ b/spec/appbundler/app_spec.rb
@@ -1,3 +1,4 @@
+# Copyright (C) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 require "spec_helper"
 require "tmpdir"
 require "fileutils"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# Copyright (C) 2017-2025 Progress Software Corporation and/or its subsidiaries or affiliates. All Rights Reserved.
 def windows?
   !!(RUBY_PLATFORM =~ /mswin|mingw|windows/)
 end


### PR DESCRIPTION
This is an automated message using the copyright-automator tool.

This PR adds Progress Software Corporation copyright notices to source files that were previously missing them.

## Automated Changes

- Added Progress copyright notices to source code files (.rb, .py, .rs, .go, .js, .erl)
- Used appropriate comment syntax for each language
- Applied year range: 2017-2025
- Copyright prepended to beginning of file (after shebang/encoding if present)

## No Other Changes Intended

- No modifications to existing copyrights
- No change to Author, Contributor, or Maintainer information
- No change to non-PSC copyright holders
